### PR TITLE
Fix: Address React key warnings in FlatLists

### DIFF
--- a/frontend/screens/HomeScreen.tsx
+++ b/frontend/screens/HomeScreen.tsx
@@ -51,7 +51,14 @@ export default function HomeScreen({ navigation }: Props): JSX.Element {
       )}
       <FlatList<Playlist>
         data={playlists}
-        keyExtractor={(item) => item.playlistId}
+        keyExtractor={(item, index) => {
+          if (item && typeof item.playlistId === 'string' && item.playlistId.length > 0) {
+            return item.playlistId;
+          }
+          // Log an error or warning if playlistId is missing or invalid
+          console.warn(`Missing or invalid playlistId for item at index ${index}. Using index as fallback key.`);
+          return `playlist-fallback-${index}`; // Fallback key
+        }}
         renderItem={({ item }) => (
           <TouchableOpacity
             style={styles.playlistItem}

--- a/frontend/screens/PlaylistDetailScreen.tsx
+++ b/frontend/screens/PlaylistDetailScreen.tsx
@@ -73,7 +73,14 @@ export default function PlaylistDetailScreen({ route, navigation }: Props): JSX.
       <Text style={styles.playlistTitle}>{playlist.name || `プレイリスト ${playlist.playlistId}`}</Text>
       <FlatList<Video>
         data={playlist.videos}
-        keyExtractor={(item) => item.videoId}
+        keyExtractor={(item, index) => {
+          if (item && typeof item.videoId === 'string' && item.videoId.length > 0) {
+            return item.videoId;
+          }
+          // Log an error or warning if videoId is missing or invalid
+          console.warn(`Missing or invalid videoId for item at index ${index} in playlist ${playlist?.playlistId}. Using index as fallback key.`);
+          return `video-fallback-${playlist?.playlistId}-${index}`; // Fallback key
+        }}
         renderItem={({ item }) => (
           <View style={styles.videoItemContainer}>
             <TouchableOpacity onPress={() => openVideo(item.url)} style={styles.videoInfo}>


### PR DESCRIPTION
Improves the `keyExtractor` functions in `HomeScreen.tsx` and `PlaylistDetailScreen.tsx` to prevent "Each child in a list should have a unique 'key' prop" warnings.

The changes ensure that:
- If a valid `playlistId` or `videoId` (non-empty string) exists for an item, it is used as the key.
- If the ID is missing or invalid, a warning is logged to the console to help diagnose potential data integrity issues.
- A unique fallback key (e.g., `playlist-fallback-${index}`) is generated using the item type and its index to satisfy React's requirement, allowing the list to render without crashing.

This makes the FlatList rendering more resilient to unexpected data issues.