### PR TITLE
refactor: Use direct URL construction for YouTube thumbnails

### DIFF
--- a/backend/index.ts
+++ b/backend/index.ts
@@ -1,6 +1,6 @@
 // Lambda function handler (index.js)
 import type { APIGatewayProxyEventV2, APIGatewayProxyResultV2 } from 'aws-lambda'; // Using V2 type for APIGatewayProxyEventV2 (recommended)
-const getYoutubeThumbnail = require('youtube-thumbnail-grabber');
+// const getYoutubeThumbnail = require('youtube-thumbnail-grabber'); // Removed
 const { DynamoDBClient } = require("@aws-sdk/client-dynamodb");
 const {
   DynamoDBDocumentClient,
@@ -100,39 +100,14 @@ exports.handler = async (event: APIGatewayProxyEventV2): Promise<APIGatewayProxy
           return createResponse(400, { error: "Invalid YouTube URL or unable to extract video ID." });
       }
 
-      let videoThumbnailUrl = null; // Initialize videoThumbnailUrl
-      try {
-          const thumbnailData = await getYoutubeThumbnail(extractedVideoId);
-
-          if (thumbnailData && typeof thumbnailData === 'object' && thumbnailData !== null) {
-              // It's an object, proceed to check for high, medium, default
-              if (thumbnailData.high && thumbnailData.high.url) {
-                  videoThumbnailUrl = thumbnailData.high.url;
-              } else if (thumbnailData.medium && thumbnailData.medium.url) {
-                  videoThumbnailUrl = thumbnailData.medium.url;
-              } else if (thumbnailData.default && thumbnailData.default.url) {
-                  videoThumbnailUrl = thumbnailData.default.url;
-              } else {
-                  console.warn(`Thumbnail data object received for video ID ${extractedVideoId}, but no suitable resolution (high, medium, default) found. Data: ${JSON.stringify(thumbnailData)}`);
-              }
-          } else if (thumbnailData) {
-              // thumbnailData is truthy but not a suitable object (e.g., a string message from the library)
-              console.warn(`Unexpected thumbnail data format received from library for video ID ${extractedVideoId}. Expected an object, but got: ${JSON.stringify(thumbnailData)}`);
-          } else {
-              // thumbnailData is null or undefined (falsy)
-              console.warn(`No thumbnail data returned by library for video ID ${extractedVideoId}.`);
-          }
-      } catch (thumbError) {
-          console.error(`Error fetching thumbnail for video ID ${extractedVideoId}:`, thumbError);
-          // videoThumbnailUrl remains null, allowing video to be saved without a thumbnail
-      }
+      const videoThumbnailUrl = `https://img.youtube.com/vi/${extractedVideoId}/hqdefault.jpg`;
 
       const newVideo = {
         videoId: randomUUID(), // Unique ID for each video
         url: videoUrl,
         title: videoTitle || `動画 - ${extractedVideoId}`, // If title is not provided, use part of the URL or a default
         addedAt: new Date().toISOString(),
-        thumbnailUrl: videoThumbnailUrl, // Use the safely extracted or null URL
+        thumbnailUrl: videoThumbnailUrl, // Use the directly constructed URL
       };
 
       // Search for existing playlist by playlistName using a QueryCommand.

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -10,8 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.821.0",
-        "@aws-sdk/lib-dynamodb": "^3.821.0",
-        "youtube-thumbnail-grabber": "^1.0.1"
+        "@aws-sdk/lib-dynamodb": "^3.821.0"
       },
       "devDependencies": {
         "@types/aws-lambda": "^8.10.149",
@@ -1712,58 +1711,11 @@
       "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
       "license": "MIT"
     },
-    "node_modules/assertion-error": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/bowser": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
       "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
       "license": "MIT"
-    },
-    "node_modules/chai": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
-      "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
-      "dependencies": {
-        "assertion-error": "^1.1.0",
-        "check-error": "^1.0.3",
-        "deep-eql": "^4.1.3",
-        "get-func-name": "^2.0.2",
-        "loupe": "^2.3.6",
-        "pathval": "^1.1.1",
-        "type-detect": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/check-error": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
-      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
-      "dependencies": {
-        "get-func-name": "^2.0.2"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/deep-eql": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
-      "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
-      "dependencies": {
-        "type-detect": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/esbuild": {
       "version": "0.25.5",
@@ -1828,22 +1780,6 @@
         "fxparser": "src/cli/cli.js"
       }
     },
-    "node_modules/get-func-name": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
-      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/loupe": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
-      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
-      "dependencies": {
-        "get-func-name": "^2.0.1"
-      }
-    },
     "node_modules/mnemonist": {
       "version": "0.38.3",
       "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.3.tgz",
@@ -1858,14 +1794,6 @@
       "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz",
       "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==",
       "license": "MIT"
-    },
-    "node_modules/pathval": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
-      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/strnum": {
       "version": "1.1.2",
@@ -1884,14 +1812,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
-    },
-    "node_modules/type-detect": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
-      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/typescript": {
       "version": "5.8.3",
@@ -1918,14 +1838,6 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/youtube-thumbnail-grabber": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/youtube-thumbnail-grabber/-/youtube-thumbnail-grabber-1.0.2.tgz",
-      "integrity": "sha512-bkMae9sizmVtpOooeaOVqmnOoVm1jg8n9wZHc3iLg3zjos4yidaVmUckPzdtSoO0bIP/Ngshy/xy0pYCHoyxOg==",
-      "dependencies": {
-        "chai": "^4.3.6"
       }
     }
   }

--- a/backend/package.json
+++ b/backend/package.json
@@ -2,7 +2,7 @@
   "name": "backend",
   "version": "1.0.0",
   "main": "dist/index.js",
- "scripts": {
+  "scripts": {
     "build": "esbuild index.ts --bundle --minify --sourcemap --platform=node --target=es2020 --outfile=dist/index.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
@@ -17,7 +17,6 @@
   },
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.821.0",
-    "@aws-sdk/lib-dynamodb": "^3.821.0",
-    "youtube-thumbnail-grabber": "^1.0.1"
+    "@aws-sdk/lib-dynamodb": "^3.821.0"
   }
 }


### PR DESCRIPTION
This commit changes the backend method for obtaining video thumbnail URLs. Previously, the `youtube-thumbnail-grabber` library was used, but it proved unreliable for some videos.

The backend (`index.ts` in `POST /videos`) now directly constructs the thumbnail URL using a standard pattern:
`https://img.youtube.com/vi/{videoId}/hqdefault.jpg`.

This change involves:
- Removing the `youtube-thumbnail-grabber` dependency from `package.json` and uninstalling it.
- Deleting all code related to calling and processing data from `youtube-thumbnail-grabber` in `index.ts`.
- Implementing the direct URL construction using the extracted video ID.

This approach simplifies the thumbnail fetching logic and aims to provide more consistent thumbnail URL generation.